### PR TITLE
Fixed incorrect image path

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@ title: GitHub Workshop Guestbook
             <div class="join-content">
                 <h3 role="section-heading">Sign the workshop guestbook!</h3>
                 <div class="flag">
-                        <img src="/images/flag.png" alt="">
+                        <img src="images/flag.png" alt="">
                 </div>
                 <a href="{{site.workshop.github}}" class="button button-white">Sign the guestbook!</a>
             </div>


### PR DESCRIPTION
The `flag.png` image was not displaying on the site because the path was incorrect. So I fixed the path.